### PR TITLE
Prepare 1 0 0 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'org.asciidoctor.convert' version '1.5.3'
 }
 
-version "1.0.0.M1"
+version "1.0.0"
 group "org.grails.plugins"
 
 apply plugin:"org.grails.grails-plugin"

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     compile 'io.dropwizard.metrics:metrics-graphite:3.1.2'
     profile "org.grails.profiles:web-plugin"
     testCompile "org.grails:grails-plugin-testing"
-    testCompile "org.grails.plugins:dropwizard-metrics:1.0.0.M3"
+    testCompile "org.grails.plugins:dropwizard-metrics:1.0.0"
 }
 
 asciidoctor {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 27 23:09:32 CET 2015
+#Wed Mar 18 10:26:29 CDT 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/src/docs/asciidoc/installation.ad
+++ b/src/docs/asciidoc/installation.ad
@@ -4,8 +4,8 @@ dependencies block of your build.gradle:
 [source,groovy,subs="attributes"]
 compile "org.grails.plugins:dropwizard-metrics-graphite:{version}"
 
-This plugin depends on version 1.0.0.M3+ of the core Dropwizard Metrics plugin, so you will also need
+This plugin depends on the core Dropwizard Metrics plugin, so you will also need
 to declare the following dependency:
 
 [source,groovy,subs="attributes"]
-compile "org.grails.plugins:dropwizard-metrics-:1.0.0.M3+"
+compile "org.grails.plugins:dropwizard-metrics:{version}"


### PR DESCRIPTION
As we've been using this plugin for more than a year, it's safe to bump the version to stable 1.0.0.